### PR TITLE
fix: blocks get cut off

### DIFF
--- a/src/compute-blocks.test.ts
+++ b/src/compute-blocks.test.ts
@@ -7,6 +7,7 @@ import {
   calcXPositions,
   alignToBottom,
   modifyOrderByType,
+  adjustTotalHeight,
 } from "./compute-blocks";
 
 describe("createInitialBlockDatum", () => {
@@ -460,5 +461,117 @@ describe("createInitialBlockDatum", () => {
     const result = modifyOrderByType("stable-balanced", blocks);
 
     expect(result).toEqual(blocks);
+  });
+
+  it("should return the original data if total height is less than or equal to maxHeight", () => {
+    const data: BlockDatum[] = [
+      {
+        value: 10,
+        name: "A",
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        fill: "#000",
+        percentage: 0,
+      },
+      {
+        value: 20,
+        name: "B",
+        x: 0,
+        y: 0,
+        width: 20,
+        height: 20,
+        fill: "#000",
+        percentage: 0,
+      },
+      {
+        value: 30,
+        name: "C",
+        x: 0,
+        y: 0,
+        width: 30,
+        height: 30,
+        fill: "#000",
+        percentage: 0,
+      },
+    ];
+    const maxHeight = 100;
+
+    const result = adjustTotalHeight(data, maxHeight);
+
+    expect(result).toEqual(data);
+  });
+
+  it("should adjust the height of the last block to fit within maxHeight", () => {
+    const data: BlockDatum[] = [
+      {
+        value: 10,
+        name: "A",
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 50,
+        fill: "#000",
+        percentage: 0,
+      },
+      {
+        value: 20,
+        name: "B",
+        x: 0,
+        y: 0,
+        width: 20,
+        height: 30,
+        fill: "#000",
+        percentage: 0,
+      },
+      {
+        value: 30,
+        name: "C",
+        x: 0,
+        y: 0,
+        width: 30,
+        height: 40,
+        fill: "#000",
+        percentage: 0,
+      },
+    ];
+    const maxHeight = 100;
+
+    const result = adjustTotalHeight(data, maxHeight);
+    console.log(result);
+
+    expect(result).toEqual([
+      {
+        value: 10,
+        name: "A",
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 50,
+        fill: "#000",
+        percentage: 0,
+      },
+      {
+        value: 20,
+        name: "B",
+        x: 0,
+        y: 0,
+        width: 20,
+        height: 30,
+        fill: "#000",
+        percentage: 0,
+      },
+      {
+        value: 30,
+        name: "C",
+        x: 0,
+        y: 0,
+        width: 60,
+        height: 20,
+        fill: "#000",
+        percentage: 0,
+      },
+    ]);
   });
 });

--- a/src/compute-blocks.ts
+++ b/src/compute-blocks.ts
@@ -65,6 +65,7 @@ export function calcWidthsAndHeights(
 /**
  *  If the total height exceeds the maximum height, adjust the height.
  *  If the height needs to be adjusted, expand the width of the last block and adjust the height.
+ *  Note: Adjust only the last block
  */
 export function adjustTotalHeight(
   data: BlockDatum[],

--- a/src/compute-blocks.ts
+++ b/src/compute-blocks.ts
@@ -62,6 +62,51 @@ export function calcWidthsAndHeights(
   }));
 }
 
+/**
+ *  If the total height exceeds the maximum height, adjust the height.
+ *  If the height needs to be adjusted, expand the width of the last block and adjust the height.
+ */
+export function adjustTotalHeight(
+  data: BlockDatum[],
+  maxHeight: number
+): BlockDatum[] {
+  const totalHeight = data.reduce((acc, d) => acc + d.height, 0);
+  if (totalHeight <= maxHeight) {
+    return data;
+  }
+
+  const diff = totalHeight - maxHeight;
+  const lastBlock = data[data.length - 1];
+  const newHeight = lastBlock.height - diff;
+  const newWidth = calcAdjustedWidthKeepingArea(
+    lastBlock.width,
+    lastBlock.height,
+    newHeight
+  );
+
+  const results = [...data];
+  results[results.length - 1] = {
+    ...lastBlock,
+    width: newWidth,
+    height: newHeight,
+  };
+
+  return results;
+}
+
+/**
+ * Calculate the width to change the height while keeping the area
+ */
+function calcAdjustedWidthKeepingArea(
+  currentWidth: number,
+  currentHeight: number,
+  targetHeight: number
+) {
+  const area = currentWidth * currentHeight;
+  const newWidth = area / targetHeight;
+  return newWidth;
+}
+
 export function modifyOrderByType(
   type: StackType,
   blocks: BlockDatum[]

--- a/src/stacked-block-chart.tsx
+++ b/src/stacked-block-chart.tsx
@@ -5,6 +5,7 @@ import Legend from "./legend";
 import {
   BlockDatum,
   addXFluctuation,
+  adjustTotalHeight,
   alignToBottom,
   calcPercentage,
   calcWidthsAndHeights,
@@ -56,6 +57,7 @@ const StackedBlockChart = forwardRef<SVGSVGElement, BalancedBlockChartProps>(
         (b) => b.map((datum) => calcPercentage(datum, total)),
         (b) => b.sort((a, b) => a.percentage - b.percentage),
         (b) => calcWidthsAndHeights(b, { multiple: 100 }),
+        (b) => adjustTotalHeight(b, svgHeight),
         (b) => modifyOrderByType(type, b),
         (b) => calcYPositions(b),
         (b) => calcXPositions(b, svgCenterX),


### PR DESCRIPTION
When the total height of the blocks exceeds the maximum height, the height of the last block is reduced to adjust.
At this time, to keep the area of the target block the same, the width is increased.
Fixes #7 