### PR TITLE
fix: shuffleArray returns the same array

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -7,7 +7,19 @@ describe("utils", () => {
     expect(result).toBeLessThanOrEqual(20);
   });
 
-  it("shuffleArray", () => {
+  it("should return the array as it is if the array has only one element", () => {
+    const arr = [1];
+    const result = shuffleArray(arr);
+    expect(result).toEqual(arr);
+  });
+
+  it("should return the array as it is if all elements are the same", () => {
+    const arr = [1, 1, 1, 1];
+    const result = shuffleArray(arr);
+    expect(result).toEqual(arr);
+  });
+
+  it("Return a shuffled array with shuffleArray", () => {
     const arr = [1, 2, 3, 4, 5];
     const result = shuffleArray(arr);
     expect(result).not.toEqual(arr);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,12 +19,34 @@ export function calcHeight(area: number, width: number) {
 
 // Receives an array and returns a shuffled array
 export function shuffleArray<T>(array: T[]): T[] {
-  const shffledArray = [...array];
-  for (let i = shffledArray.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const temp = shffledArray[i];
-    shffledArray[i] = shffledArray[j];
-    shffledArray[j] = temp;
+  if (array.length <= 1) {
+    return array;
   }
+
+  const allEqual = array.every((e) => e === array[0]);
+  if (allEqual) {
+    return array;
+  }
+
+  let shffledArray = [];
+  let attempts = 0;
+  const maxAttempts = 100;
+
+  do {
+    shffledArray = [...array];
+
+    for (let i = shffledArray.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      const temp = shffledArray[i];
+      shffledArray[i] = shffledArray[j];
+      shffledArray[j] = temp;
+    }
+
+    attempts++;
+  } while (
+    shffledArray.every((e, i) => e === array[i]) &&
+    attempts < maxAttempts
+  );
+
   return shffledArray;
 }


### PR DESCRIPTION
The shuffleArray function sometimes returns the same array even after shuffling. 
This pull request fixes this issue. 
However, if the array has only one element, it returns the original array. 
Also, if all elements in the array are the same, it returns the original array.
In other cases, it loops until the shuffled array is different from the original array. 
To be safe, a maximum number of attempts is set.