### PR TITLE
refactor: extract block computation logic into useComputedBlocks hook

### DIFF
--- a/src/stacked-block-chart.tsx
+++ b/src/stacked-block-chart.tsx
@@ -1,20 +1,8 @@
-import { ComponentPropsWithRef, forwardRef, useEffect, useState } from "react";
+import { ComponentPropsWithRef, forwardRef } from "react";
 import Block from "./block";
 import BlockLabels from "./block-labels";
 import Legend from "./legend";
-import {
-  BlockDatum,
-  addXFluctuation,
-  adjustSameValueBlocks,
-  adjustTotalHeight,
-  alignToBottom,
-  calcPercentage,
-  calcWidthsAndHeights,
-  calcXPositions,
-  calcYPositions,
-  createInitialBlockDatum,
-  modifyOrderByType,
-} from "./compute-blocks";
+import { useComputedBlocks } from "./use-computed-blocks";
 import { useRandomGenerator } from "./use-random-generator";
 
 export type StackType = "stable-balanced" | "unstable-inverted" | "shuffled";
@@ -48,43 +36,12 @@ export const StackedBlockChart = forwardRef<
   ) => {
     const svgWidth = 400;
     const svgHeight = 300;
-    const blocksOffsetX = 40;
     const legendWidth = 100;
     const legendItemHeight = 16;
     const legendPaddingTop = 10;
     const legendPaddingRight = 10;
-    const [blocks, setBlocks] = useState<BlockDatum[]>([]);
-    const [legendItems, setLegendItems] = useState<
-      { name: string; color: string }[]
-    >([]);
     const { getRandomInt } = useRandomGenerator(seed);
-
-    useEffect(() => {
-      const initialBlocks = data.map(createInitialBlockDatum);
-      const total = initialBlocks.reduce((acc, d) => acc + d.value, 0);
-      const svgCenterX = (svgWidth - legendWidth) / 2 - blocksOffsetX;
-
-      const ops: ((b: BlockDatum[]) => BlockDatum[])[] = [
-        (b) => b.map((datum) => calcPercentage(datum, total)),
-        (b) => b.sort((a, b) => a.percentage - b.percentage),
-        (b) => calcWidthsAndHeights(b, getRandomInt, { multiple: 100 }),
-        (b) => adjustSameValueBlocks(b),
-        (b) => adjustTotalHeight(b, svgHeight),
-        (b) => modifyOrderByType(b, stackType, getRandomInt),
-        (b) => calcYPositions(b),
-        (b) => calcXPositions(b, svgCenterX),
-        (b) => addXFluctuation(b, getRandomInt),
-        (b) => alignToBottom(b, svgHeight),
-      ];
-
-      const blocks = ops.reduce((acc, op) => op(acc), initialBlocks);
-      const legendItems = blocks.map((d) => {
-        return { name: d.name, color: d.fill };
-      });
-
-      setBlocks(blocks);
-      setLegendItems(legendItems);
-    }, [stackType, data, getRandomInt]);
+    const { blocks, legendItems } = useComputedBlocks(data, stackType, getRandomInt);
 
     return (
       <>

--- a/src/use-computed-blocks.ts
+++ b/src/use-computed-blocks.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import {
+  BlockDatum,
+  addXFluctuation,
+  adjustSameValueBlocks,
+  adjustTotalHeight,
+  alignToBottom,
+  calcPercentage,
+  calcWidthsAndHeights,
+  calcXPositions,
+  calcYPositions,
+  createInitialBlockDatum,
+  modifyOrderByType,
+} from "./compute-blocks";
+import { StackedBlockDatum, StackType } from "./stacked-block-chart";
+
+const SVG_WIDTH = 400;
+const SVG_HEIGHT = 300;
+const BLOCKS_OFFSET_X = 40;
+const LEGEND_WIDTH = 100;
+
+type UseComputedBlocksResult = {
+  blocks: BlockDatum[];
+  legendItems: { name: string; color: string }[];
+};
+
+export function useComputedBlocks(
+  data: StackedBlockDatum[],
+  stackType: StackType,
+  getRandomInt: (min: number, max: number) => number
+): UseComputedBlocksResult {
+  const [blocks, setBlocks] = useState<BlockDatum[]>([]);
+  const [legendItems, setLegendItems] = useState<
+    { name: string; color: string }[]
+  >([]);
+
+  useEffect(() => {
+    const initialBlocks = data.map(createInitialBlockDatum);
+    const total = initialBlocks.reduce((acc, d) => acc + d.value, 0);
+    const svgCenterX = (SVG_WIDTH - LEGEND_WIDTH) / 2 - BLOCKS_OFFSET_X;
+
+    const ops: ((b: BlockDatum[]) => BlockDatum[])[] = [
+      (b) => b.map((datum) => calcPercentage(datum, total)),
+      (b) => b.sort((a, b) => a.percentage - b.percentage),
+      (b) => calcWidthsAndHeights(b, getRandomInt, { multiple: 100 }),
+      (b) => adjustSameValueBlocks(b),
+      (b) => adjustTotalHeight(b, SVG_HEIGHT),
+      (b) => modifyOrderByType(b, stackType, getRandomInt),
+      (b) => calcYPositions(b),
+      (b) => calcXPositions(b, svgCenterX),
+      (b) => addXFluctuation(b, getRandomInt),
+      (b) => alignToBottom(b, SVG_HEIGHT),
+    ];
+
+    const computed = ops.reduce((acc, op) => op(acc), initialBlocks);
+    setBlocks(computed);
+    setLegendItems(computed.map((d) => ({ name: d.name, color: d.fill })));
+  }, [data, stackType, getRandomInt]);
+
+  return { blocks, legendItems };
+}


### PR DESCRIPTION
## Summary

- `StackedBlockChart` コンポーネント内の `useEffect` + `useState` によるブロック計算ロジックを `useComputedBlocks` カスタムフックに切り出した
- 新規ファイル `src/use-computed-blocks.ts` を作成し、SVG サイズ等の定数もフック内に集約
- コンポーネントがレンダリングのみに専念する構造になった

## Test plan

- [ ] `pnpm test` が全テスト通過することを確認
- [ ] Storybook でチャートが正常に描画されることを確認（stable-balanced / unstable-inverted / shuffled の3種類）

https://claude.ai/code/session_01MBeCjzu2iwC7EYo1zPice3

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBeCjzu2iwC7EYo1zPice3)_