### PR TITLE
Export `StackedBlockChartProps` from public chart module

### DIFF
--- a/src/stacked-block-chart.tsx
+++ b/src/stacked-block-chart.tsx
@@ -7,7 +7,7 @@ import { useComputedBlocks } from "./use-computed-blocks";
 
 export type { StackedBlockDatum, StackType } from "./types/chart";
 
-type StackedBlockChartProps = ComponentPropsWithRef<"svg"> & {
+export type StackedBlockChartProps = ComponentPropsWithRef<"svg"> & {
   stackType: StackType;
   data: StackedBlockDatum[];
   seed?: number;


### PR DESCRIPTION
### Motivation
- Expose the component props type so consumers can reference `StackedBlockChartProps` from the package while keeping existing public types stable.

### Description
- Changed `src/stacked-block-chart.tsx` to `export type StackedBlockChartProps = ComponentPropsWithRef<"svg"> & { ... }`, verified `src/index.ts` already uses `export * from "./stacked-block-chart"` so no additional re-exports were required, and kept `StackedBlockDatum` / `StackType` exports unchanged.

### Testing
- Ran the test suite with `npm test -- --run` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e20551b94832a95612af83ce5a3bf)