### PR TITLE
Expose configurable SVG size and legend width for StackedBlockChart and propagate to layout logic

### DIFF
--- a/src/stacked-block-chart.tsx
+++ b/src/stacked-block-chart.tsx
@@ -12,6 +12,9 @@ export type StackedBlockChartProps = ComponentPropsWithRef<"svg"> & {
   data: StackedBlockDatum[];
   seed?: number;
   showDataLabels?: boolean;
+  width?: number;
+  height?: number;
+  legendWidth?: number;
 };
 
 export const StackedBlockChart = forwardRef<
@@ -24,17 +27,23 @@ export const StackedBlockChart = forwardRef<
       data,
       seed = 42,
       showDataLabels = true,
+      width = 400,
+      height = 300,
+      legendWidth = 100,
       ...rest
     }: StackedBlockChartProps,
     ref
   ) => {
-    const svgWidth = 400;
-    const svgHeight = 300;
-    const legendWidth = 100;
+    const svgWidth = width;
+    const svgHeight = height;
     const legendItemHeight = 16;
     const legendPaddingTop = 10;
     const legendPaddingRight = 10;
-    const { blocks, legendItems } = useComputedBlocks(data, stackType, seed);
+    const { blocks, legendItems } = useComputedBlocks(data, stackType, seed, {
+      width: svgWidth,
+      height: svgHeight,
+      legendWidth,
+    });
 
     return (
       <>

--- a/src/use-computed-blocks.ts
+++ b/src/use-computed-blocks.ts
@@ -19,10 +19,10 @@ import type {
   StackType,
 } from "./types/chart";
 
-const SVG_WIDTH = 400;
-const SVG_HEIGHT = 300;
+const DEFAULT_SVG_WIDTH = 400;
+const DEFAULT_SVG_HEIGHT = 300;
 const BLOCKS_OFFSET_X = 40;
-const LEGEND_WIDTH = 100;
+const DEFAULT_LEGEND_WIDTH = 100;
 
 type UseComputedBlocksResult = {
   blocks: BlockDatum[];
@@ -32,7 +32,12 @@ type UseComputedBlocksResult = {
 export function useComputedBlocks(
   data: StackedBlockDatum[],
   stackType: StackType,
-  seed: number
+  seed: number,
+  {
+    width = DEFAULT_SVG_WIDTH,
+    height = DEFAULT_SVG_HEIGHT,
+    legendWidth = DEFAULT_LEGEND_WIDTH,
+  }: { width?: number; height?: number; legendWidth?: number } = {}
 ): UseComputedBlocksResult {
   return useMemo(() => {
     const generator = xoroshiro128plus(seed);
@@ -41,19 +46,19 @@ export function useComputedBlocks(
 
     const initialBlocks = data.map(createInitialBlockDatum);
     const total = initialBlocks.reduce((acc, d) => acc + d.value, 0);
-    const svgCenterX = (SVG_WIDTH - LEGEND_WIDTH) / 2 - BLOCKS_OFFSET_X;
+    const svgCenterX = (width - legendWidth) / 2 - BLOCKS_OFFSET_X;
 
     const ops: ((b: BlockDatum[]) => BlockDatum[])[] = [
       (b) => b.map((datum) => calcPercentage(datum, total)),
       (b) => b.sort((a, b) => a.percentage - b.percentage),
       (b) => calcWidthsAndHeights(b, getRandomInt, { multiple: 100 }),
       (b) => adjustSameValueBlocks(b),
-      (b) => adjustTotalHeight(b, SVG_HEIGHT),
+      (b) => adjustTotalHeight(b, height),
       (b) => modifyOrderByType(b, stackType, getRandomInt),
       (b) => calcYPositions(b),
       (b) => calcXPositions(b, svgCenterX),
       (b) => addXFluctuation(b, getRandomInt),
-      (b) => alignToBottom(b, SVG_HEIGHT),
+      (b) => alignToBottom(b, height),
     ];
 
     const computed = ops.reduce((acc, op) => op(acc), initialBlocks);
@@ -61,5 +66,5 @@ export function useComputedBlocks(
       blocks: computed,
       legendItems: computed.map((d) => ({ name: d.name, color: d.fill })),
     };
-  }, [data, stackType, seed]);
+  }, [data, stackType, seed, width, height, legendWidth]);
 }


### PR DESCRIPTION
### Motivation
- Allow callers to control the rendered SVG size and legend width so layout and block geometry can adapt to different container sizes.

### Description
- Added optional props `width`, `height`, and `legendWidth` to `StackedBlockChart` with defaults of `400`, `300`, and `100` respectively and wired them into the component.
- Updated the call to `useComputedBlocks` to pass an options object `{ width, height, legendWidth }` instead of relying on hard-coded constants.
- Refactored `useComputedBlocks` to accept the optional size parameters, replace internal `SVG_WIDTH`, `SVG_HEIGHT`, and `LEGEND_WIDTH` constants with `DEFAULT_*` fallbacks, and use the passed values in layout calculations (centering, total height adjustment, and alignment).
- Added the new size props to the memoization dependency array so computed blocks update when dimensions change.

### Testing
- Ran the automated test suite with `yarn test` and all tests passed.
- Performed a typecheck/build with `yarn build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e3c2214e8832ab39fabb4d08713a7)