### PR TITLE
docs: add API Reference for StackedBlockChartProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ npm install toy-block-charts
 
 ## Usage
 
+## API Reference
+
+### `StackedBlockChartProps`
+
+| Prop | Required | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `stackType` | Yes | `stable-balanced \| unstable-inverted \| shuffled` | - | Stacking algorithm type. |
+| `data` | Yes | `{ name: string; value: number; fill?: string }[]` | - | Input data for each block segment. If `fill` is not provided, colors are assigned automatically (see `WithoutSettingFills` story behavior). |
+| `seed` | No | `number` | `42` | Seed value used for reproducibility in `shuffled`-based layouts. |
+| `showDataLabels` | No | `boolean` | `true` | Whether to render labels on blocks. |
+| `width` / `height` | No | `ComponentPropsWithRef<"svg">["width"]` / `ComponentPropsWithRef<"svg">["height"]` | `undefined` | SVG size options. They are passed to the `<svg>` `width`/`height` attributes, while `viewBox="0 0 400 300"` is fixed. When specified, they also constrain responsive rendering via `maxWidth` / `maxHeight` styles. |
+
 ### Stable Balanced
 
 ![stable balanced chart](./assets/image-stable-balanced.jpg)


### PR DESCRIPTION
### Motivation

- Provide a concise API reference directly under `Usage` so consumers can quickly see `StackedBlockChart` props, types, and default behaviors (including `fill` auto-assignment, `seed` reproducibility, and SVG sizing semantics).

### Description

- Added an `API Reference` section to `README.md` that includes a `StackedBlockChartProps` table documenting `stackType`, `data`, `seed` (default `42`), `showDataLabels` (default `true`), and `width`/`height` behavior, and notes that `fill` is auto-assigned when omitted.
- Ensured the documented types and defaults match the implementation in `src/stacked-block-chart/stacked-block-chart.tsx` and `src/stacked-block-chart/model/types.ts`.

### Testing

- Inspected `README.md`, `src/stacked-block-chart/stacked-block-chart.tsx`, and `src/stacked-block-chart/model/types.ts` to validate types and defaults using `sed`/file reads, applied the patch, and committed the change (`git commit`, resulting commit `8435bb5`), and created PR metadata via `make_pr`, all of which succeeded.
- No automated unit tests were added or modified for this documentation change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a166594938c832a83031262310046ac)